### PR TITLE
Override cargo target dir

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ case "$1" in
   build)
     echo "Building silicon.nvim from source..."
 
-    cargo build --release 
+    cargo build --release --target-dir ./target
 
     # Place the compiled library where Neovim can find it.
     mkdir -p lua


### PR DESCRIPTION
Currently, `install.sh build` will fail if cargo target dir is changed in cargo config or using env variables, this PR fixes this by passing `--target-dir ./target` to cargo.
Ideally we should use `cargo config` but it's unstable.