### PR TITLE
feat: Add window title option.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,8 +1423,7 @@ checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 [[package]]
 name = "silicon"
 version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb05b35c00bb05eddcdbcf0d330937cc7daa2492e440f0f3838be29c990ebc1"
+source = "git+https://github.com/Aloxaf/silicon#cf3668c9ee43ebdae608db3f7b3449c588b8411f"
 dependencies = [
  "anyhow",
  "clipboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ features = ["jpeg", "png", "jpeg_rayon"]
 
 [patch.crates-io]
 nvim-oxi = { git = "https://github.com/noib3/nvim-oxi" }
+silicon = { git = "https://github.com/Aloxaf/silicon" }

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The `setup` function accepts the following table:
   tab_width = 4,
   round_corner = true,
   window_controls = true,
+  window_title = nil, -- a function returning window title as a string
   watermark = {
     text = nil, -- add this to enable watermark on the bottom-right.
     color = '#222',

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use oxi::{
     conversion::{self, FromObject, ToObject},
     lua,
     serde::{Deserializer, Serializer},
-    Object,
+    Object, Function,
 };
 use serde::{Deserialize, Serialize};
 
@@ -58,6 +58,7 @@ pub struct Opts {
 
     pub round_corner: Option<bool>,
     pub window_controls: Option<bool>,
+    pub window_title: Option<Function<(),String>>,
 
     #[serde(default)]
     pub output: OutputOpts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,14 @@ fn get_formatter(
     opts: &Opts,
     adder: ShadowAdder,
 ) -> Result<silicon::formatter::ImageFormatter, Error> {
+    let title = match opts.window_title.clone() {
+        Some(f) => Some(f.call(()).map_err(|e| {
+            Error::Other(format!(
+                "[silicon.nvim]: Error calling `window_title` function. {e}"
+            ))
+        })?),
+        None => None,
+    };
     ImageFormatterBuilder::new()
         .font(fonts.to_owned())
         .tab_width(opts.tab_width.unwrap_or(4))
@@ -187,6 +195,7 @@ fn get_formatter(
         .line_offset(opts.line_offset.unwrap_or(1))
         .line_number(opts.line_number.unwrap_or(false))
         .window_controls(opts.window_controls.unwrap_or(true))
+        .window_title(title)
         .round_corner(opts.round_corner.unwrap_or(true))
         .shadow_adder(adder)
         .build()


### PR DESCRIPTION
Add an option to customize window title of the screenshot.

# Example
```lua
require('silicon').setup {
  ...
  window_title = function()
    -- use relative file path as window title
    return vim.fn.fnamemodify(vim.fn.bufname(vim.fn.bufnr()), ':~:.')
  end,
  ...
}
```
![image](https://user-images.githubusercontent.com/41364823/219902415-9809d10b-30f5-4107-af4d-c77d8ed6230e.png)
