### PR TITLE
Feat/wl clip support

### DIFF
--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -38,7 +38,7 @@ pub fn dump_image_to_clipboard(image: &DynamicImage) -> anyhow::Result<()> {
         let wl_copy_err = wl_copy_cmd.unwrap_err();
         let xclip_err = xclip_cmd.unwrap_err();
         let combined_err = format_err!(
-            "Both wl-copy & xclip failed to copy:\n\twl-copy error:{}\n\txclip error:{}",
+            "Both wl-copy & xclip failed to copy:\nwl-copy error:{}\nxclip error:{}",
             &wl_copy_err.to_string(),
             &xclip_err.to_string()
         );

--- a/src/clipboard.rs
+++ b/src/clipboard.rs
@@ -38,7 +38,7 @@ pub fn dump_image_to_clipboard(image: &DynamicImage) -> anyhow::Result<()> {
         let wl_copy_err = wl_copy_cmd.unwrap_err();
         let xclip_err = xclip_cmd.unwrap_err();
         let combined_err = format_err!(
-            "Both wl-copy & xclip failed to copy:\nwl-copy error:{}\nxclip error:{}",
+            "Both wl-copy & xclip failed to copy, wl-copy error:{}| xclip error:{}",
             &wl_copy_err.to_string(),
             &xclip_err.to_string()
         );


### PR DESCRIPTION
This allows linux users to have either `xclip` or `wl-clipboard` installed and have images copied into their clipboard. Functionally this enables Wayland support without any configuration user side.

I tested with both only `xclip` and `wl-copy` installed and the copy process worked as expected. The correct errors were thrown when both were missing. Additional verification by other Linux users may help with finding any weird errors that my system does not expose.

I am sure there are more idiomatic ways of handling the errors and actions I am taking within the changes in this PR, any changes/recommendations are welcomed.

Closes #21 