### PR TITLE
style: include .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+[*.{rs,toml}]
+indent_size = 4
+
+[*.sh]
+indent_size = 2


### PR DESCRIPTION
EditorConfig is a standard meant to configure editors (in the name). It allows developers to unify coding experiences on the project by having the same indents, spacing, line endings, etc.

Adding the `.editorconfig` file makes working on various files within the repository easier, for instance, on the `install.sh` file which my editor defaults to using tabs in.

See [EditorConfig's website](https://editorconfig.org/) for more details.

If this is not a solution suited to the project, then perhaps setting vim modelines in files may be best. Either way, it'd be nice to have a consistent editing experience compliant with others.