### PR TITLE
fix: use alternative oxi binding to get filetype

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ fn save_image(opts: Opts) -> Result<(), Error> {
     // HACK: This allows us to avoid currently broken oxi APIs to get the filetype option.
     // Instead we call into VimL and get the value that way -- super ghetto, but it works without
     // any breaking changes from what I can tell.
-    let ft = oxi::api::exec("echo &filetype", true)?.unwrap();
+    let ft = oxi::api::exec("echo &filetype", true)?.ok_or_else(|| Error::Other(String::from("Unable to determine filetype!")))?;
 
     let syntax = ps
         .find_syntax_by_token(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,12 +36,14 @@ fn save_image(opts: Opts) -> Result<(), Error> {
 
     let code = get_lines(&opts)?;
 
-    let ft: oxi::String = Buffer::current().get_option("filetype")?;
+    // HACK: This allows us to avoid currently broken oxi APIs to get the filetype option.
+    // Instead we call into VimL and get the value that way -- super ghetto, but it works without
+    // any breaking changes from what I can tell.
+    let ft = oxi::api::exec("echo &filetype", true)?.unwrap();
 
     let syntax = ps
         .find_syntax_by_token(
-            ft.as_str()
-                .map_err(|e| Error::Other(format!("utf error: {e}")))?,
+            &ft
         )
         .ok_or_else(|| Error::Other("Could not find syntax for filetype.".to_owned()))?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ use utils::{parse_str_color, IntoFont, IntoFontStyle};
 
 use nvim_oxi as oxi;
 use oxi::{
-    api::{self, opts::*, types::*, Buffer, Error},
+    api::{self, opts::*, types::*, Error},
     Dictionary, Function,
 };
 use silicon::{


### PR DESCRIPTION
This solution works, but is quite hacky. It doesn't seem to break the api for end users though, and currently works on nightly. It likely works on 0.8 as well.

This closes #26 for now. Once `nvim-oxi` gets updated this hack around should be replaced with what was previously there.

This should also close #10.

I have only tested against nightly, it would be wise to also test this against `0.8`, as this may end up being a breaking change for older neovim builds (though I doubt it, it calls directly into VimL).