### PR TITLE
feat: add selection highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The `setup` function accepts the following table:
   line_offset = 1,
   tab_width = 4,
   gobble = false, -- trim extra identation.
+  highlight_selection = false, -- capture the whole file and highlight selected lines
   round_corner = true,
   window_controls = true,
   window_title = nil, -- a function returning window title as a string

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,8 @@ pub struct Opts {
     #[serde(default)]
     pub watermark: WatermarkOpts,
 
+    pub highlight_selection: Option<bool>,
+
     #[serde(alias = "line1")]
     #[serde(default)]
     pub start: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,6 +199,15 @@ fn get_formatter(
         .window_title(title)
         .round_corner(opts.round_corner.unwrap_or(true))
         .shadow_adder(adder)
+        .highlight_lines(if opts.highlight_selection.unwrap_or_default() {
+            let mut range = vec![];
+            for x in opts.start..=opts.end {
+                range.push(x as u32);
+            }
+            range
+        } else {
+            vec![]
+        })
         .build()
         .map_err(|e| Error::Other(format!("font error: {e}")))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -56,8 +56,16 @@ pub fn get_lines(opts: &Opts) -> Result<String, Error> {
         "getbufline",
         (
             api::call_function::<_, i32>("bufnr", ('%',))?,
-            opts.start as i32,
-            opts.end as i32,
+            if opts.highlight_selection.unwrap_or_default() {
+                1
+            } else {
+                opts.start as i32
+            },
+            if opts.highlight_selection.unwrap_or_default() {
+                "$".to_owned()
+            } else {
+                format!("{}", opts.end)
+            },
         ),
     )?
     .iter()


### PR DESCRIPTION
add an option to capture the whole file and highlight the selected lines

usage example:
```lua
vim.api.nvim_create_user_command('CaptureSel', function(opts)
  require('silicon').capture {
    line1: opts.line1,
    line2: opts.line2,
    highlight_selection: true,
    ...
  }
end, { range = true })
```

closes #30